### PR TITLE
Enforces case sensitivity on registered spec types on Master

### DIFF
--- a/lib/minitest-spec-rails/init/action_controller.rb
+++ b/lib/minitest-spec-rails/init/action_controller.rb
@@ -6,7 +6,7 @@ module MiniTestSpecRails
 
       included do
         register_spec_type(self) { |desc| Class === desc && desc < ActionController::Metal }
-        register_spec_type(/Controller( ?Test)?\z/i, self)
+        register_spec_type(/Controller( ?Test)?\z/, self)
         register_spec_type(self) { |desc| Class === desc && desc < self }
         register_rails_test_case self
       end

--- a/lib/minitest-spec-rails/init/action_dispatch.rb
+++ b/lib/minitest-spec-rails/init/action_dispatch.rb
@@ -5,7 +5,7 @@ module MiniTestSpecRails
       extend ActiveSupport::Concern
 
       included do
-        register_spec_type(/(Acceptance|Integration) ?Test\z/i, self)
+        register_spec_type(/(Acceptance|Integration) ?Test\z/, self)
         register_spec_type(self) { |desc| Class === desc && desc < self }
         register_rails_test_case self
       end

--- a/lib/minitest-spec-rails/init/action_mailer.rb
+++ b/lib/minitest-spec-rails/init/action_mailer.rb
@@ -6,7 +6,7 @@ module MiniTestSpecRails
 
       included do
         register_spec_type(self) { |desc| Class === desc && desc < ActionMailer::Base }
-        register_spec_type(/Mailer( ?Test)?\z/i, self)
+        register_spec_type(/Mailer( ?Test)?\z/, self)
         register_spec_type(self) { |desc| Class === desc && desc < self }
         register_rails_test_case self
         before { setup_minitest_spec_rails_mailer_class }

--- a/lib/minitest-spec-rails/init/action_view.rb
+++ b/lib/minitest-spec-rails/init/action_view.rb
@@ -6,7 +6,7 @@ module MiniTestSpecRails
 
       included do
         class_attribute :_helper_class
-        register_spec_type(/(Helper|View)( ?Test)?\z/i, self)
+        register_spec_type(/(Helper|View)( ?Test)?\z/, self)
         register_spec_type(self) { |desc| Class === desc && desc < self }
         register_rails_test_case self
         before { setup_minitest_spec_rails_helper_class }
@@ -17,7 +17,7 @@ module MiniTestSpecRails
       def helper_class=(new_class)
         self._helper_class = new_class
       end
-      
+
       def helper_class
         if current_helper_class = self._helper_class
           current_helper_class

--- a/test/cases/action_controller_test.rb
+++ b/test/cases/action_controller_test.rb
@@ -13,10 +13,10 @@ class ActionControllerTest < MiniTestSpecRails::TestCase
     assert_controller MiniTest::Spec.spec_type("WidgetController")
     assert_controller MiniTest::Spec.spec_type("WidgetControllerTest")
     assert_controller MiniTest::Spec.spec_type("Widget Controller Test")
-    # And is not case sensitive
-    assert_controller MiniTest::Spec.spec_type("widgetcontroller")
-    assert_controller MiniTest::Spec.spec_type("widgetcontrollertest")
-    assert_controller MiniTest::Spec.spec_type("widget controller test")
+    # And is case sensitive
+    refute_controller MiniTest::Spec.spec_type("widgetcontroller")
+    refute_controller MiniTest::Spec.spec_type("widgetcontrollertest")
+    refute_controller MiniTest::Spec.spec_type("widget controller test")
   end
 
   it 'wont match spec type for non space characters' do

--- a/test/cases/action_dispatch_test.rb
+++ b/test/cases/action_dispatch_test.rb
@@ -5,34 +5,36 @@ class ModelsController < ApplicationController;  end
 class ActionControllerTest < MiniTestSpecRails::TestCase
 
   it 'resolves spec type for matching acceptance strings' do
-   assert_dispatch MiniTest::Spec.spec_type("WidgetAcceptanceTest")
-   assert_dispatch MiniTest::Spec.spec_type("Widget Acceptance Test")
-   assert_dispatch MiniTest::Spec.spec_type("widgetacceptancetest")
-   assert_dispatch MiniTest::Spec.spec_type("widget acceptance test")
- end
+    assert_dispatch MiniTest::Spec.spec_type("WidgetAcceptanceTest")
+    assert_dispatch MiniTest::Spec.spec_type("Widget Acceptance Test")
+    # And is case sensitive
+    refute_dispatch MiniTest::Spec.spec_type("widgetacceptancetest")
+    refute_dispatch MiniTest::Spec.spec_type("widget acceptance test")
+  end
 
- it 'wont match spec type for space characters in acceptance strings' do
-   refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\tTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\rTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\nTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\fTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget AcceptanceXTest")
- end
+  it 'wont match spec type for space characters in acceptance strings' do
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\tTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\rTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\nTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\fTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget AcceptanceXTest")
+  end
 
- it 'resolves spec type for matching integration strings' do
-   assert_dispatch MiniTest::Spec.spec_type("WidgetIntegrationTest")
-   assert_dispatch MiniTest::Spec.spec_type("Widget Integration Test")
-   assert_dispatch MiniTest::Spec.spec_type("widgetintegrationtest")
-   assert_dispatch MiniTest::Spec.spec_type("widget integration test")
- end
+  it 'resolves spec type for matching integration strings' do
+    assert_dispatch MiniTest::Spec.spec_type("WidgetIntegrationTest")
+    assert_dispatch MiniTest::Spec.spec_type("Widget Integration Test")
+    # And is case sensitive
+    refute_dispatch MiniTest::Spec.spec_type("widgetintegrationtest")
+    refute_dispatch MiniTest::Spec.spec_type("widget integration test")
+  end
 
- it 'wont match spec type for space characters in integration strings' do
-   refute_dispatch MiniTest::Spec.spec_type("Widget Integration\tTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget Integration\rTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget Integration\nTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget Integration\fTest")
-   refute_dispatch MiniTest::Spec.spec_type("Widget IntegrationXTest")
- end
+  it 'wont match spec type for space characters in integration strings' do
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\tTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\rTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\nTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\fTest")
+    refute_dispatch MiniTest::Spec.spec_type("Widget IntegrationXTest")
+  end
 
 
   private

--- a/test/cases/action_mailer_test.rb
+++ b/test/cases/action_mailer_test.rb
@@ -14,10 +14,10 @@ class ActionMailerTest < MiniTestSpecRails::TestCase
     assert_mailer MiniTest::Spec.spec_type("WidgetMailer")
     assert_mailer MiniTest::Spec.spec_type("WidgetMailerTest")
     assert_mailer MiniTest::Spec.spec_type("Widget Mailer Test")
-    # And is not case sensitive
-    assert_mailer MiniTest::Spec.spec_type("widgetmailer")
-    assert_mailer MiniTest::Spec.spec_type("widgetmailertest")
-    assert_mailer MiniTest::Spec.spec_type("widget mailer test")
+    # And is case sensitive
+    refute_mailer MiniTest::Spec.spec_type("widgetmailer")
+    refute_mailer MiniTest::Spec.spec_type("widgetmailertest")
+    refute_mailer MiniTest::Spec.spec_type("widget mailer test")
   end
 
   it 'wont match spec type for non space characters' do

--- a/test/cases/action_view_test.rb
+++ b/test/cases/action_view_test.rb
@@ -6,20 +6,20 @@ class ActionViewTest < MiniTestSpecRails::TestCase
     assert_view MiniTest::Spec.spec_type("WidgetHelper")
     assert_view MiniTest::Spec.spec_type("WidgetHelperTest")
     assert_view MiniTest::Spec.spec_type("Widget Helper Test")
-    # And is not case sensitive
-    assert_view MiniTest::Spec.spec_type("widgethelper")
-    assert_view MiniTest::Spec.spec_type("widgethelpertest")
-    assert_view MiniTest::Spec.spec_type("widget helper test")
+    # And is case sensitive
+    refute_view MiniTest::Spec.spec_type("widgethelper")
+    refute_view MiniTest::Spec.spec_type("widgethelpertest")
+    refute_view MiniTest::Spec.spec_type("widget helper test")
   end
 
   it 'resolves spec type for matching view strings' do
     assert_view MiniTest::Spec.spec_type("WidgetView")
     assert_view MiniTest::Spec.spec_type("WidgetViewTest")
     assert_view MiniTest::Spec.spec_type("Widget View Test")
-    # And is not case sensitive
-    assert_view MiniTest::Spec.spec_type("widgetview")
-    assert_view MiniTest::Spec.spec_type("widgetviewtest")
-    assert_view MiniTest::Spec.spec_type("widget view test")
+    # And is case sensitive
+    refute_view MiniTest::Spec.spec_type("widgetview")
+    refute_view MiniTest::Spec.spec_type("widgetviewtest")
+    refute_view MiniTest::Spec.spec_type("widget view test")
   end
 
   it 'wont match spec type for non space characters' do


### PR DESCRIPTION
Case insensitivity causes issues with class names where certain classes
would be considered something they were not (See #25)
