### PR TITLE
Fix railtie.rb for Rails 4.1

### DIFF
--- a/lib/minitest-spec-rails/railtie.rb
+++ b/lib/minitest-spec-rails/railtie.rb
@@ -3,26 +3,27 @@ module MiniTestSpecRails
     
     config.minitest_spec_rails = ActiveSupport::OrderedOptions.new
     config.minitest_spec_rails.mini_shoulda = false
-    
-    config.before_initialize do |app|
-      return unless Rails.env.test?
-      require 'active_support'
-      require 'minitest-spec-rails/init/active_support'
-      ActiveSupport.on_load(:action_view) do
-        require 'minitest-spec-rails/init/action_view'
-      end
-      ActiveSupport.on_load(:action_controller) do 
-        require 'minitest-spec-rails/init/action_controller'
-        require 'minitest-spec-rails/init/action_dispatch'
-      end
-      ActiveSupport.on_load(:action_mailer) do
-        require 'minitest-spec-rails/init/action_mailer'
-      end
-    end
 
-    initializer 'minitest-spec-rails.mini_shoulda', :group => :all do |app|
-      return unless Rails.env.test?
-      require 'minitest-spec-rails/init/mini_shoulda' if app.config.minitest_spec_rails.mini_shoulda
+    if Rails.env.test?
+      config.before_initialize do |app|
+        return unless Rails.env.test?
+        require 'active_support'
+        require 'minitest-spec-rails/init/active_support'
+        ActiveSupport.on_load(:action_view) do
+          require 'minitest-spec-rails/init/action_view'
+        end
+        ActiveSupport.on_load(:action_controller) do
+          require 'minitest-spec-rails/init/action_controller'
+          require 'minitest-spec-rails/init/action_dispatch'
+        end
+        ActiveSupport.on_load(:action_mailer) do
+          require 'minitest-spec-rails/init/action_mailer'
+        end
+      end
+
+      initializer 'minitest-spec-rails.mini_shoulda', :group => :all do |app|
+        require 'minitest-spec-rails/init/mini_shoulda' if app.config.minitest_spec_rails.mini_shoulda
+      end
     end
     
   end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/13271 for an explanation why the return statements in before_initialize and the initializer block cause errors. I am not sure why this did not show in #37. While it seems not to occur in Ruby 1.8.7, I'd expect it in 1.9.3.

In any case, this change fixes the (non-test) start of my application with Rails 4.1.0.beta1 and Ruby 2.1.
