### PR TITLE
Set the spec description when using ActiveSupport's Declarative#test

### DIFF
--- a/lib/minitest-spec-rails/dsl.rb
+++ b/lib/minitest-spec-rails/dsl.rb
@@ -24,7 +24,7 @@ module MiniTestSpecRails
       end
 
       def test(name, &block)
-        it { self.instance_eval(&block) }
+        it(name) { self.instance_eval(&block) }
       end
 
       def described_class


### PR DESCRIPTION
When using minitest-spec-rails in a Rails codebase with lots of test "some description" do.... style tests (from  ActiveSupport's Declarative#test), the description is always set to anonymous. This change sets the description from the name passed to the test method.
