### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ describe User do
 end
 ```
 
-RSpec 3 is also moving away from the outter describe test type inference, as described in this line from their [release notes](https://www.relishapp.com/rspec/rspec-rails/v/3-1/docs/changelog).
+RSpec 3 is also moving away from the outer describe test type inference, as described in this line from their [release notes](https://www.relishapp.com/rspec/rspec-rails/v/3-1/docs/changelog).
 
 > Spec types are no longer inferred by location, they instead need to be explicitly tagged. The old behaviour is enabled by config.infer_spec_type_from_file_location!, which is still supplied in the default generated spec_helper.rb. (Xavier Shay, Myron Marston)
 
-Not that we want to mimic RSpec, but the aim of this gem is very straight forward and minimilistic. We simply want to expose the Minitest Spec::DSL and core assertion style within ActiveSupport. Period. So it is very possible that us matching outter describe to classes is simply going to go away one day soon.
+Not that we want to mimic RSpec, but the aim of this gem is very straight forward and minimilistic. We simply want to expose the Minitest Spec::DSL and core assertion style within ActiveSupport. Period. So it is very possible that us matching outer describe to classes is simply going to go away one day soon.
 
 Just for reference, here is a full list of each of Rails test case we support.
 
@@ -211,7 +211,7 @@ class PostTests < ActiveSupport::TestCase
 end
 ```
 
-If you are in the assertions provided by shoulda-context like `assert_same_elements`, then you may want to consider copying them [from here](https://github.com/thoughtbot/shoulda-context/blob/master/lib/shoulda/context/assertions.rb) and including them in `MiniTest::Spec` yourself. I personally recommend just replacing these assertions with something more modern. A few examples are below.
+If you prefer the assertions provided by shoulda-context like `assert_same_elements`, then you may want to consider copying them [from here](https://github.com/thoughtbot/shoulda-context/blob/master/lib/shoulda/context/assertions.rb) and including them in `MiniTest::Spec` yourself. I personally recommend just replacing these assertions with something more modern. A few examples are below.
 
 ```ruby
 assert_same_elements a, b  # From


### PR DESCRIPTION
* outer, not outter
* “If you are in the” = “If you prefer"