### PR TITLE
Review/Pedantic Stuff

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
-Rake::TestTask.new   do |t|
+Rake::TestTask.new do |t|
   t.libs = ['lib','test']
   t.test_files = Dir.glob("test/**/*_test.rb").sort
   t.verbose = true

--- a/lib/minitest-spec-rails/dsl.rb
+++ b/lib/minitest-spec-rails/dsl.rb
@@ -30,12 +30,12 @@ module MiniTestSpecRails
       def described_class
         nil
       end
-      
+
     end
 
     def described_class
       self.class.described_class
     end
-    
+
   end
 end

--- a/lib/minitest-spec-rails/init/action_controller.rb
+++ b/lib/minitest-spec-rails/init/action_controller.rb
@@ -10,7 +10,7 @@ module MiniTestSpecRails
         register_spec_type(/Controller( ?Test)?\z/, self)
         register_spec_type(self) { |desc| Class === desc && desc < self }
       end
-      
+
       module Descriptions
 
         def described_class

--- a/lib/minitest-spec-rails/railtie.rb
+++ b/lib/minitest-spec-rails/railtie.rb
@@ -4,28 +4,30 @@ module MiniTestSpecRails
     config.minitest_spec_rails = ActiveSupport::OrderedOptions.new
     config.minitest_spec_rails.mini_shoulda = false
 
-    config.before_initialize do |app|
-      require 'active_support'
-      require 'minitest-spec-rails/init/active_support'
-      ActiveSupport.on_load(:action_controller) do
-        require 'minitest-spec-rails/init/action_controller'
-        require 'minitest-spec-rails/init/action_dispatch'
+    if ENV['RAILS_ENV'] == 'test'
+      config.before_initialize do |app|
+        require 'active_support'
+        require 'minitest-spec-rails/init/active_support'
+        ActiveSupport.on_load(:action_controller) do
+          require 'minitest-spec-rails/init/action_controller'
+          require 'minitest-spec-rails/init/action_dispatch'
+        end
+        ActiveSupport.on_load(:action_mailer) do
+          require 'minitest-spec-rails/init/action_mailer'
+        end
+        ActiveSupport.on_load(:active_job) do
+          require 'minitest-spec-rails/init/active_job'
+        end
       end
-      ActiveSupport.on_load(:action_mailer) do
-        require 'minitest-spec-rails/init/action_mailer'
-      end
-      ActiveSupport.on_load(:active_job) do
-        require 'minitest-spec-rails/init/active_job'
-      end
-    end if ENV['RAILS_ENV'] == 'test'
 
-    initializer 'minitest-spec-rails.action_view', :after => 'action_view.setup_action_pack', :group => :all do |app|
-      require 'minitest-spec-rails/init/action_view'
-    end if ENV['RAILS_ENV'] == 'test'
+      initializer 'minitest-spec-rails.action_view', :after => 'action_view.setup_action_pack', :group => :all do |app|
+        require 'minitest-spec-rails/init/action_view'
+      end
 
-    initializer 'minitest-spec-rails.mini_shoulda', :group => :all do |app|
-      require 'minitest-spec-rails/init/mini_shoulda' if app.config.minitest_spec_rails.mini_shoulda
-    end if ENV['RAILS_ENV'] == 'test'
+      initializer 'minitest-spec-rails.mini_shoulda', :group => :all do |app|
+        require 'minitest-spec-rails/init/mini_shoulda' if app.config.minitest_spec_rails.mini_shoulda
+      end
+    end
 
   end
 end

--- a/minitest-spec-rails.gemspec
+++ b/minitest-spec-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.license     = 'MIT'
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.require_paths = ['lib']
   gem.add_runtime_dependency     'minitest', '~> 5.0'
   gem.add_runtime_dependency     'rails', '>= 4.1'

--- a/test/cases/action_controller_test.rb
+++ b/test/cases/action_controller_test.rb
@@ -27,7 +27,6 @@ class ActionControllerTest < MiniTestSpecRails::TestCase
     refute_controller MiniTest::Spec.spec_type("Widget ControllerXTest")
   end
 
-
   private
 
   def assert_controller(actual)

--- a/test/cases/action_dispatch_test.rb
+++ b/test/cases/action_dispatch_test.rb
@@ -36,7 +36,6 @@ class ActionControllerTest < MiniTestSpecRails::TestCase
     refute_dispatch MiniTest::Spec.spec_type("Widget IntegrationXTest")
   end
 
-
   private
 
   def assert_dispatch(actual)

--- a/test/cases/action_mailer_test.rb
+++ b/test/cases/action_mailer_test.rb
@@ -28,7 +28,6 @@ class ActionMailerTest < MiniTestSpecRails::TestCase
     refute_mailer MiniTest::Spec.spec_type("Widget MailerXTest")
   end
 
-
   private
 
   def assert_mailer(actual)

--- a/test/cases/action_view_test.rb
+++ b/test/cases/action_view_test.rb
@@ -30,7 +30,6 @@ class ActionViewTest < MiniTestSpecRails::TestCase
     refute_view MiniTest::Spec.spec_type("Widget HelperXTest")
   end
 
-
   private
 
   def assert_view(actual)

--- a/test/cases/active_job_test.rb
+++ b/test/cases/active_job_test.rb
@@ -29,7 +29,6 @@ class ActiveJobTest < MiniTestSpecRails::TestCase
     refute_job MiniTest::Spec.spec_type("Widget JobXTest")
   end
 
-
   private
 
   def assert_job(actual)

--- a/test/cases/active_support_test.rb
+++ b/test/cases/active_support_test.rb
@@ -26,20 +26,20 @@ class ActiveSupportTest < MiniTestSpecRails::TestCase
 end
 
 class ActiveSupportCallbackTest < ActiveSupport::TestCase
- 
+
   setup :foo
   setup :bar
- 
+
   it 'works' do
     @foo.must_equal 'foo'
     @bar.must_equal 'bar'
   end
- 
+
   private
- 
+
   def foo ; @foo = 'foo' ; end
   def bar ; @bar = 'bar' ; end
- 
+
 end
 
 class ActiveSupportSpecTest < ActiveSupport::TestCase

--- a/test/dummy_app/app/helpers/users_helper.rb
+++ b/test/dummy_app/app/helpers/users_helper.rb
@@ -2,7 +2,7 @@ module UsersHelper
 
   def render_users_list(users)
     content_tag :ul do
-      users.map{ |user| content_tag :li, user.email }.join.html_safe
+      users.map { |user| content_tag :li, user.email }.join.html_safe
     end
   end
 

--- a/test/dummy_app/app/models/post.rb
+++ b/test/dummy_app/app/models/post.rb
@@ -2,5 +2,4 @@ class Post < ActiveRecord::Base
 
   belongs_to :user
 
-
 end

--- a/test/dummy_app/app/models/user.rb
+++ b/test/dummy_app/app/models/user.rb
@@ -2,5 +2,4 @@ class User < ActiveRecord::Base
 
   has_many :posts
 
-
 end

--- a/test/dummy_tests/application_controller_test.rb
+++ b/test/dummy_tests/application_controller_test.rb
@@ -50,12 +50,12 @@ class ApplicationControllerTest < ActionController::TestCase
   end
   describe 'level 1' do
     it 'reflects' do
-      described_class.must_equal  ApplicationController
+      described_class.must_equal ApplicationController
       self.class.described_class.must_equal ApplicationController
     end
     describe 'level 2' do
       it 'reflects' do
-        described_class.must_equal  ApplicationController
+        described_class.must_equal ApplicationController
         self.class.described_class.must_equal ApplicationController
       end
     end

--- a/test/dummy_tests/integration_test.rb
+++ b/test/dummy_tests/integration_test.rb
@@ -34,7 +34,7 @@ module IntegrationTests
       end
 
     end
-    
+
   end
 end
 

--- a/test/dummy_tests/user_mailer_test.rb
+++ b/test/dummy_tests/user_mailer_test.rb
@@ -57,12 +57,12 @@ class UserMailerTest < ActionMailer::TestCase
   end
   describe 'level 1' do
     it 'reflects' do
-      described_class.must_equal  UserMailer
+      described_class.must_equal UserMailer
       self.class.described_class.must_equal UserMailer
     end
     describe 'level 2' do
       it 'reflects' do
-        described_class.must_equal  UserMailer
+        described_class.must_equal UserMailer
         self.class.described_class.must_equal UserMailer
       end
     end

--- a/test/dummy_tests/user_test.rb
+++ b/test/dummy_tests/user_test.rb
@@ -31,7 +31,7 @@ module UserTests
       end
 
     end
-    
+
   end
 end
 

--- a/test/dummy_tests/user_test.rb
+++ b/test/dummy_tests/user_test.rb
@@ -43,12 +43,12 @@ class UserTest < ActiveSupport::TestCase
   end
   describe 'level 1' do
     it 'reflects' do
-      described_class.must_equal  User
+      described_class.must_equal User
       self.class.described_class.must_equal User
     end
     describe 'level 2' do
       it 'reflects' do
-        described_class.must_equal  User
+        described_class.must_equal User
         self.class.described_class.must_equal User
       end
     end

--- a/test/dummy_tests/users_controller_test.rb
+++ b/test/dummy_tests/users_controller_test.rb
@@ -17,7 +17,7 @@ module UsersControllerTests
     private
 
     def put_update_0
-      rails5? ? put(:update, :params => {:id => 0}) : put(:update, :id => 0)
+      rails5? ? put(:update, :params => { :id => 0 }) : put(:update, :id => 0)
     end
 
   end

--- a/test/dummy_tests/users_helper_test.rb
+++ b/test/dummy_tests/users_helper_test.rb
@@ -44,12 +44,12 @@ class UsersHelperTest < ActionView::TestCase
   end
   describe 'level 1' do
     it 'reflects' do
-      described_class.must_equal  UsersHelper
+      described_class.must_equal UsersHelper
       self.class.described_class.must_equal UsersHelper
     end
     describe 'level 2' do
       it 'reflects' do
-        described_class.must_equal  UsersHelper
+        described_class.must_equal UsersHelper
         self.class.described_class.must_equal UsersHelper
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,5 @@ module MiniTestSpecRails
 
     include MiniTestSpecRails::SharedTestCaseBehavior
 
-
   end
 end

--- a/test/test_helper_dummy.rb
+++ b/test/test_helper_dummy.rb
@@ -5,5 +5,4 @@ class ActiveSupport::TestCase
   fixtures :all
   include MiniTestSpecRails::SharedTestCaseBehavior
 
-
 end


### PR DESCRIPTION
Reviewed as requested. Very solid, my two (somewhat pedantic) issues are the repeated conditional in `lib/minitest-spec-rails/railtie.rb` and some spacing things. They are all on separate commits if you choose to cherry pick over merging everything in.

## Repeated conditional (2aa654d)

Right now `before_initialize`, `initializer 'minitest-spec-rails.action_view'` and `initializer 'minitest-spec-rails.mini_shoulda'` read as all needing to fire if `ENV['RAILS_ENV'] == 'test'` is true. I feel like having them live inside of the same if block conveys this fact clearer to the reader over adding the ifs at the end of each of the blocks. 

## Whitespace (38d8d93..63971ef)

I feel that it would behoove you to adopt rubocop. There are a number of whitespace issues, while easily resolved, do tend to clutter up diffs. Going forward, rubocop should help keep these issues from cropping back up and needing remediation.

I've corrected the few that I'm certain you would be ok with. There are still a few more (attached below). Let me know if you want me to write up a rubocop config matching your style and correct the rest of them.

<details>
<summary>Remaining Issues</summary>
```
52   Style/StringLiterals
38   Style/EmptyLinesAroundClassBody
35   Style/EmptyLinesAroundModuleBody
34   Style/EmptyLinesAroundBlockBody
17   Style/Documentation
16   Metrics/LineLength
11   Style/CaseEquality
8    Style/SpaceBeforeSemicolon
7    Style/TrailingWhitespace
3    Style/EmptyLineBetweenDefs
3    Style/GlobalVars
3    Style/SingleLineMethods
2    Style/Alias
1    Metrics/MethodLength
1    Style/BlockDelimiters
1    Style/ClassAndModuleChildren
1    Style/FileName
1    Style/MutableConstant
1    Style/SpecialGlobalVars
1    Style/WordArray
--
236  Total
```
</details>