### PR TITLE
Prevent minitest from running on process exit.

### DIFF
--- a/lib/minitest-spec-rails/railtie.rb
+++ b/lib/minitest-spec-rails/railtie.rb
@@ -24,7 +24,6 @@ module MiniTestSpecRails
     initializer 'minitest-spec-rails.after.load_active_support', :after => :load_active_support, :group => :all do |app|
       if Rails.env.test?
         require 'minitest-spec-rails/init/mini_shoulda' if app.config.minitest_spec_rails.mini_shoulda
-        require 'minitest/autorun'
       end
     end
 


### PR DESCRIPTION
Attempt at resolving https://github.com/metaskills/minitest-spec-rails/issues/85 by not requiring `minitest/autorun`

Requiring `minitest/autorun` makes [minitest](https://github.com/seattlerb/minitest/blob/74a91648eac138668eff177a320983a6ea1b1988/lib/minitest.rb#L46-L58) run on process exit. This causes minitest to run an empty test suite for every rake command.

Opening PR to see what travis says.