### PR TITLE
Update Rails version numbers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Make Rails Use MiniTest::Spec!
 
 
-The minitest-spec-rails gem makes it easy to use the MiniTest::Spec DSL within your existing Rails 2.3, 3.x or 4.x test suite. It does this by forcing ActiveSupport::TestCase to utilize the MiniTest::Spec::DSL.
+The minitest-spec-rails gem makes it easy to use the MiniTest::Spec DSL within your existing Rails 3.x, 4.x or 5.x test suite. It does this by forcing ActiveSupport::TestCase to utilize the MiniTest::Spec::DSL.
 
 [![Gem Version](https://badge.fury.io/rb/minitest-spec-rails.png)](http://badge.fury.io/rb/minitest-spec-rails)
 [![Build Status](https://secure.travis-ci.org/metaskills/minitest-spec-rails.png)](http://travis-ci.org/metaskills/minitest-spec-rails)


### PR DESCRIPTION
Based on [travis.yml](https://github.com/metaskills/minitest-spec-rails/blob/master/.travis.yml) it looks like Rails 2 is no longer supported. This updates the readme to reflect that.