### PR TITLE
Switch to vector badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 The minitest-spec-rails gem makes it easy to use the MiniTest::Spec DSL within your existing Rails 2.3, 3.x or 4.x test suite. It does this by forcing ActiveSupport::TestCase to utilize the MiniTest::Spec::DSL.
 
-[![Gem Version](https://badge.fury.io/rb/minitest-spec-rails.png)](http://badge.fury.io/rb/minitest-spec-rails)
-[![Build Status](https://secure.travis-ci.org/metaskills/minitest-spec-rails.png)](http://travis-ci.org/metaskills/minitest-spec-rails)
-[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/metaskills/minitest-spec-rails)
+[![Gem Version](https://badge.fury.io/rb/minitest-spec-rails.svg)](http://badge.fury.io/rb/minitest-spec-rails)
+[![Build Status](https://secure.travis-ci.org/metaskills/minitest-spec-rails.svg)](http://travis-ci.org/metaskills/minitest-spec-rails)
+[![Maintainability](https://api.codeclimate.com/v1/badges/e67addda6fd009b68349/maintainability)](https://codeclimate.com/github/metaskills/minitest-spec-rails/maintainability)
 
 
 ## Usage
@@ -284,6 +284,4 @@ We have a few branches for each major Rails version.
 * master - Currently tracks Rails 4.1 which uses Minitest 5.0.
 
 Our current build status is:
-[![Build Status](https://secure.travis-ci.org/metaskills/minitest-spec-rails.png)](http://travis-ci.org/metaskills/minitest-spec-rails)
-
-
+[![Build Status](https://secure.travis-ci.org/metaskills/minitest-spec-rails.svg)](http://travis-ci.org/metaskills/minitest-spec-rails)


### PR DESCRIPTION
...because raster makes eyes bleed on retina displays :sunglasses:

**Before:**

<img width="381" alt="minitest-spec-rails make rails use minitest spec 2018-04-03 16-34-01" src="https://user-images.githubusercontent.com/740/38279303-db97edee-375c-11e8-8cee-3f257d2d59e9.png">

**After:**

<img width="467" alt="readme md 2018-04-03 16-34-35" src="https://user-images.githubusercontent.com/740/38279314-e72cd2e6-375c-11e8-8067-eb4c62b5542d.png">
