### PR TITLE
Depend on railties instead of the meta package rails

### DIFF
--- a/minitest-spec-rails.gemspec
+++ b/minitest-spec-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.require_paths = ['lib']
   gem.add_runtime_dependency     'minitest', '>= 5.0'
-  gem.add_runtime_dependency     'rails', '>= 4.1'
+  gem.add_runtime_dependency     'railties', '>= 4.1'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Rails meta package will download all the framework instead of just selected package.
