### PR TITLE
Fix warnings about autoloading ActionText::ContentHelper and ActionText::TagHelper

### DIFF
--- a/lib/minitest-spec-rails/railtie.rb
+++ b/lib/minitest-spec-rails/railtie.rb
@@ -21,7 +21,9 @@ module MiniTestSpecRails
       end
 
       initializer 'minitest-spec-rails.action_view', after: 'action_view.setup_action_pack', group: :all do |_app|
-        require 'minitest-spec-rails/init/action_view'
+        ActiveSupport.on_load(:action_view) do
+          require 'minitest-spec-rails/init/action_view'
+        end
       end
 
       initializer 'minitest-spec-rails.mini_shoulda', group: :all do |app|


### PR DESCRIPTION
Fixes #103.

I'm not 100% sure about this, as I "figured it out" by trial-and-error, but it seems to get rid of the warnings at least for my Rails app. Not 100% sure this is the right place to put the on_load hook either (it also fixes the warning if you wrap it around [the last line of action_view.rb](https://github.com/metaskills/minitest-spec-rails/blob/dc4c16f53bf24e6abb86ceb93a50c2dff801b306/lib/minitest-spec-rails/init/action_view.rb#L22)), but I'm guessing this is the preferred approach, looking at the other code in this same file?