### PR TITLE
Increase the railities mini version of dependencies

### DIFF
--- a/minitest-spec-rails.gemspec
+++ b/minitest-spec-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.require_paths = ['lib']
   gem.add_runtime_dependency     'minitest', '>= 5.0'
-  gem.add_runtime_dependency     'railties', '>= 4.1'
+  gem.add_runtime_dependency     'railties', '>= 5.0'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Railities < 5.0 has no method Rails::Application.reloader introduce in
Rails 5.0.

The mini-spec-rails since 6.1 is not compatible anymore to rails < 5.0 ( https://github.com/metaskills/minitest-spec-rails/blob/8e3d79d7211e643df1154e9d91f7e6563ce10d60/lib/minitest-spec-rails/init/action_view.rb#L22 ) and the usage of `Rails::Application.reloader`

It's better to increase to rails 5.0 has minimum dependencies because Rails < 5.0
is too old to continue to maintain