### PR TITLE
Removes hard-coded 'ENV['RAILS_ENV']=='test' check from railtie.rb

### DIFF
--- a/lib/minitest-spec-rails/railtie.rb
+++ b/lib/minitest-spec-rails/railtie.rb
@@ -3,32 +3,30 @@ module MiniTestSpecRails
     config.minitest_spec_rails = ActiveSupport::OrderedOptions.new
     config.minitest_spec_rails.mini_shoulda = false
 
-    if ENV['RAILS_ENV'] == 'test'
-      config.before_initialize do |_app|
-        require 'active_support'
-        require 'minitest-spec-rails/init/active_support'
-        require 'minitest-spec-rails/parallelize'
-        ActiveSupport.on_load(:action_controller) do
-          require 'minitest-spec-rails/init/action_controller'
-          require 'minitest-spec-rails/init/action_dispatch'
-        end
-        ActiveSupport.on_load(:action_mailer) do
-          require 'minitest-spec-rails/init/action_mailer'
-        end
-        ActiveSupport.on_load(:active_job) do
-          require 'minitest-spec-rails/init/active_job'
-        end
+    config.before_initialize do |_app|
+      require 'active_support'
+      require 'minitest-spec-rails/init/active_support'
+      require 'minitest-spec-rails/parallelize'
+      ActiveSupport.on_load(:action_controller) do
+        require 'minitest-spec-rails/init/action_controller'
+        require 'minitest-spec-rails/init/action_dispatch'
       end
+      ActiveSupport.on_load(:action_mailer) do
+        require 'minitest-spec-rails/init/action_mailer'
+      end
+      ActiveSupport.on_load(:active_job) do
+        require 'minitest-spec-rails/init/active_job'
+      end
+    end
 
-      initializer 'minitest-spec-rails.action_view', after: 'action_view.setup_action_pack', group: :all do |_app|
-        ActiveSupport.on_load(:action_view) do
-          require 'minitest-spec-rails/init/action_view'
-        end
+    initializer 'minitest-spec-rails.action_view', after: 'action_view.setup_action_pack', group: :all do |_app|
+      ActiveSupport.on_load(:action_view) do
+        require 'minitest-spec-rails/init/action_view'
       end
+    end
 
-      initializer 'minitest-spec-rails.mini_shoulda', group: :all do |app|
-        require 'minitest-spec-rails/init/mini_shoulda' if app.config.minitest_spec_rails.mini_shoulda
-      end
+    initializer 'minitest-spec-rails.mini_shoulda', group: :all do |app|
+      require 'minitest-spec-rails/init/mini_shoulda' if app.config.minitest_spec_rails.mini_shoulda
     end
   end
 end


### PR DESCRIPTION
The hard-coded check in https://github.com/metaskills/minitest-spec-rails/blob/master/lib/minitest-spec-rails/railtie.rb#L6 made it impossible to use specs in custom testing environments. 

Instead of hard-coding this, it makes more sense to include the code whenever the gem is loaded. (i.e. using the groups in the Gemfile).