### PR TITLE
Add support for ActionCable::Channel::TestCase

### DIFF
--- a/lib/minitest-spec-rails/init/action_cable.rb
+++ b/lib/minitest-spec-rails/init/action_cable.rb
@@ -1,0 +1,22 @@
+module MiniTestSpecRails
+  module Init
+    module ActionCableBehavior
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :_helper_class
+        register_spec_type(/(Channel)( ?Test)?\z/, self)
+        register_spec_type(self) { |desc| desc.is_a?(Class) && desc < self }
+        extend Descriptions
+      end
+
+      module Descriptions
+        def described_class
+          determine_default_helper_class(name)
+        end
+      end
+    end
+  end
+end
+
+ActionCable::Channel::TestCase.include MiniTestSpecRails::Init::ActionCableBehavior

--- a/lib/minitest-spec-rails/railtie.rb
+++ b/lib/minitest-spec-rails/railtie.rb
@@ -7,6 +7,9 @@ module MiniTestSpecRails
       require 'active_support'
       require 'minitest-spec-rails/init/active_support'
       require 'minitest-spec-rails/parallelize'
+      ActiveSupport.on_load(:action_cable) do
+        require 'minitest-spec-rails/init/action_cable'
+      end
       ActiveSupport.on_load(:action_controller) do
         require 'minitest-spec-rails/init/action_controller'
         require 'minitest-spec-rails/init/action_dispatch'

--- a/test/cases/action_cable_test.rb
+++ b/test/cases/action_cable_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ModelsChannel < ApplicationCable::Channel;  end
+
+class ActionCableChannelTest < MiniTestSpecRails::TestCase
+  it 'matches spec type for class constants' do
+    assert_channel_test MiniTest::Spec.spec_type(ApplicationCable::Channel)
+    assert_channel_test MiniTest::Spec.spec_type(ModelsChannel)
+  end
+
+  it 'matches spec type for strings' do
+    assert_channel_test MiniTest::Spec.spec_type('WidgetChannel')
+    assert_channel_test MiniTest::Spec.spec_type('WidgetChannelTest')
+    assert_channel_test MiniTest::Spec.spec_type('Widget Channel Test')
+    # And is case sensitive
+    refute_channel_test MiniTest::Spec.spec_type('widgetcontroller')
+    refute_channel_test MiniTest::Spec.spec_type('widgetcontrollertest')
+    refute_channel_test MiniTest::Spec.spec_type('widget controller test')
+  end
+
+  it 'wont match spec type for non space characters' do
+    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\tTest")
+    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\rTest")
+    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\nTest")
+    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\fTest")
+    refute_channel_test MiniTest::Spec.spec_type('Widget ChannelXTest')
+  end
+
+  private
+
+  def assert_channel_test(actual)
+    assert_equal ActionCable::Channel::TestCase, actual
+  end
+
+  def refute_channel_test(actual)
+    refute_equal ActionCable::Channel::TestCase, actual
+  end
+end


### PR DESCRIPTION
This adds support for `ActionCable::Channel::TestCase`; with this it's possible to write your test using a describe-block:

```ruby
describe FooBarChannel do
  before do
    stub_connection(...) # <--- this is a test helper from ActionCable::Channel::TestCase
  end
  # ...
end
```