### PR TITLE
Upgrading to `7.0.0` causes `action_cable/channel` to throw an expection

### DIFF
--- a/lib/minitest-spec-rails/init/action_cable.rb
+++ b/lib/minitest-spec-rails/init/action_cable.rb
@@ -1,4 +1,7 @@
-require 'action_cable/channel'
+unless defined?(ActionCable::Channel)
+  require 'action_cable/channel'
+end
+
 require 'action_cable/channel/test_case'
 
 module MiniTestSpecRails


### PR DESCRIPTION
I was upgrading `minitest-spec-rails` from `6.2.0` to `7.0.0` and this caused the new `lib/minitest-spec-rails/init/action_cable.rb` file to throw an exception because it couldn't require `action_cable/channel`, which seems very weird:

```
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require': cannot load such file -- action_cable/channel (LoadError)
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/minitest-spec-rails-7.0.0/lib/minitest-spec-rails/init/action_cable.rb:1:in `<top (required)>'
```

<details>
<summary>Full Backtrace</summary>

<pre>
bundle exec rails db:setup

/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require': cannot load such file -- action_cable/channel (LoadError)
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/minitest-spec-rails-7.0.0/lib/minitest-spec-rails/init/action_cable.rb:1:in `<top (required)>'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/minitest-spec-rails-7.0.0/lib/minitest-spec-rails/railtie.rb:11:in `block (2 levels) in <class:Railtie>'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/activesupport/lib/active_support/lazy_load_hooks.rb:99:in `instance_eval'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/activesupport/lib/active_support/lazy_load_hooks.rb:99:in `block in execute_hook'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/activesupport/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/activesupport/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/activesupport/lib/active_support/lazy_load_hooks.rb:78:in `block in run_load_hooks'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/activesupport/lib/active_support/lazy_load_hooks.rb:77:in `each'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/activesupport/lib/active_support/lazy_load_hooks.rb:77:in `run_load_hooks'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/actioncable/lib/action_cable/server/base.rb:95:in `<module:Server>'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/actioncable/lib/action_cable/server/base.rb:6:in `<module:ActionCable>'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/actioncable/lib/action_cable/server/base.rb:5:in `<top (required)>'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:30:in `require'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:30:in `require'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:135:in `const_get'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:135:in `cget'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:169:in `block in actual_eager_load_dir'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:40:in `block in ls'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:25:in `each'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:25:in `ls'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:164:in `actual_eager_load_dir'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:16:in `each'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader.rb:329:in `block in eager_load_all'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader.rb:327:in `each'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/loader.rb:327:in `eager_load_all'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/railties/lib/rails/application/finisher.rb:80:in `block in <module:Finisher>'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/railties/lib/rails/initializable.rb:32:in `instance_exec'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/railties/lib/rails/initializable.rb:32:in `run'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/railties/lib/rails/initializable.rb:61:in `block in run_initializers'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:228:in `block in tsort_each'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:431:in `each_strongly_connected_component_from'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:349:in `block in each_strongly_connected_component'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:347:in `each'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:347:in `call'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:347:in `each_strongly_connected_component'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:226:in `tsort_each'
  from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/tsort.rb:205:in `tsort_each'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/railties/lib/rails/initializable.rb:60:in `run_initializers'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-d026af43c35c/railties/lib/rails/application.rb:420:in `initialize!'
  from /home/runner/work/[project]/[project]/config/environment.rb:7:in `<top (required)>'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
  from /home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
  from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
  from <internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
  from -e:1:in `<main>'
</pre>
</details>


I was able to fix it by wrapping the `require` statement in a `unless defined?(ActionCable::Channel)`. I can't really explain how and why this is happening and just thought I post this here in case anyone else is running into it. 

I'm also not sure if this is the proper fix for the cause, but it seems to make it work again. I'm currently using a fork as a workaround which patches in the above mentioned `unless` condition.

### Versions

* `minitest-spec-rails`: `7.0.0`
* `rails`: `edge` @ `d026af43c35c`
* `Ruby`: `3.2.2`
