### PR TITLE
use Minitest instead of MiniTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <a href="https://dhh.dk/2012/rails-is-omakase.html"><img src="https://user-images.githubusercontent.com/2381/34084174-246174da-e34a-11e7-9d36-94c9cde7b63d.png" width="233" height="154" /></a>
 
-# Make Rails Use MiniTest::Spec!
+# Make Rails Use Minitest::Spec!
 ##### https://dhh.dk/2012/rails-is-omakase.html
 
-The minitest-spec-rails gem makes it easy to use the MiniTest::Spec DSL within your existing Rails 2.3, 3.x or 4.x test suite. It does this by forcing ActiveSupport::TestCase to utilize the MiniTest::Spec::DSL.
+The minitest-spec-rails gem makes it easy to use the Minitest::Spec DSL within your existing Rails 2.3, 3.x or 4.x test suite. It does this by forcing ActiveSupport::TestCase to utilize the Minitest::Spec::DSL.
 
 [![Gem Version](https://badge.fury.io/rb/minitest-spec-rails.svg)](http://badge.fury.io/rb/minitest-spec-rails)
 [![CI Status](https://github.com/metaskills/minitest-spec-rails/workflows/CI/badge.svg)](https://launch-editor.github.com/actions?nwo=metaskills%2Fminitest-spec-rails&workflowID=CI)
@@ -12,7 +12,7 @@ The minitest-spec-rails gem makes it easy to use the MiniTest::Spec DSL within y
 
 ## Usage
 
-Existing or new Rails applications that use the default Rails testing structure can simply drop in the minitest-spec-gem and start writing their tests in the new spec DSL. Since MiniTest::Spec is built on top of MiniTest::Unit, a replacement for Test::Unit, all of your existing tests will continue to work.
+Existing or new Rails applications that use the default Rails testing structure can simply drop in the minitest-spec-gem and start writing their tests in the new spec DSL. Since Minitest::Spec is built on top of Minitest::Unit, a replacement for Test::Unit, all of your existing tests will continue to work.
 
 
 #### Rails 4.1 to 6.0
@@ -36,9 +36,9 @@ end
 ```
 
 
-### How is this different than MiniTest::Rails?
+### How is this different than Minitest::Rails?
 
-To start off both Mike Moore (@blowmage) and I have worked together and we both LOVE MiniTest::Spec. Both projects aim to advocate MiniTest and make Rails integration as easy as possible. However, there are a few key differences in our projects. Some of these differences may go away in time too. As always, choose the tool you think fits your needs. So how, is minitest-spec-rails different than [minitest-rails](https://github.com/blowmage/minitest-rails)?
+To start off both Mike Moore (@blowmage) and I have worked together and we both LOVE Minitest::Spec. Both projects aim to advocate MiniTest and make Rails integration as easy as possible. However, there are a few key differences in our projects. Some of these differences may go away in time too. As always, choose the tool you think fits your needs. So how, is minitest-spec-rails different than [minitest-rails](https://github.com/blowmage/minitest-rails)?
 
   * We aim to leverage existing Rails test directories and files!
   * No special test helper and/or generators.
@@ -47,7 +47,7 @@ To start off both Mike Moore (@blowmage) and I have worked together and we both 
   * Fully support Ruby 1.8.7 with all legacy Test::Unit behavior.
   * Compatibility with ActiveSupport::TestCase's setup and teardowns.
 
-So the goal of this project is to make Rails 3 or 4 applications just work as if rails-core had decided to support MiniTest::Spec all along. We believe that eventually that day will come and when it does, all your tests will still work! So bundle up and get started!
+So the goal of this project is to make Rails 3 or 4 applications just work as if rails-core had decided to support Minitest::Spec all along. We believe that eventually that day will come and when it does, all your tests will still work! So bundle up and get started!
 
 ```ruby
 gem 'minitest-spec-rails'
@@ -56,13 +56,13 @@ gem 'minitest-spec-rails'
 
 ## Test Styles
 
-This <a href="https://chriskottom.com/freebies/cheatsheets_free.pdf">cheat sheet</a> shows both the MiniTest::Unit assertions along with the MiniTest::Spec assertion syntax. Remember, MiniTest::Spec is built on top of MiniTest::Unit which is a Test::Unit replacement. That means you can mix and match styles as you upgrade from Test::Unit to a more modern style. For example, both of these would work in MiniTest::Spec and are interchangeable.
+This <a href="https://chriskottom.com/freebies/cheatsheets_free.pdf">cheat sheet</a> shows both the Minitest::Unit assertions along with the Minitest::Spec assertion syntax. Remember, Minitest::Spec is built on top of Minitest::Unit which is a Test::Unit replacement. That means you can mix and match styles as you upgrade from Test::Unit to a more modern style. For example, both of these would work in Minitest::Spec and are interchangeable.
 
 ```ruby
-# MiniTest::Unit Assertion Style:
+# Minitest::Unit Assertion Style:
 assert_equal 100, foo
 
-# MiniTest::Spec Assertion Style:
+# Minitest::Spec Assertion Style:
 expect(foo).must_equal 100
 ```
 
@@ -191,7 +191,7 @@ class PostTests < ActiveSupport::TestCase
 end
 ```
 
-If you prefer the assertions provided by shoulda-context like `assert_same_elements`, then you may want to consider copying them [from here](https://github.com/thoughtbot/shoulda-context/blob/master/lib/shoulda/context/assertions.rb) and including them in `MiniTest::Spec` yourself. I personally recommend just replacing these assertions with something more modern. A few examples are below.
+If you prefer the assertions provided by shoulda-context like `assert_same_elements`, then you may want to consider copying them [from here](https://github.com/thoughtbot/shoulda-context/blob/master/lib/shoulda/context/assertions.rb) and including them in `Minitest::Spec` yourself. I personally recommend just replacing these assertions with something more modern. A few examples are below.
 
 ```ruby
 assert_same_elements a, b         # From
@@ -203,7 +203,7 @@ expect(a).wont_include b      # To
 
 ### Matchers
 
-**I highly suggest that you stay away from matchers** since MiniTest::Spec gives you all the tools you need to write good tests. Staying away from matchers will make your code's tests live longer. So my advice is to stay away from things like `.should ==` and just write `.must_equal` instead. However, if matchers are really your thing, I recommend the [minitest-matchers](https://github.com/wojtekmach/minitest-matchers) gem. You can also check out the [valid_attribute](https://github.com/bcardarella/valid_attribute) gem built on top of minitest-matchers.
+**I highly suggest that you stay away from matchers** since Minitest::Spec gives you all the tools you need to write good tests. Staying away from matchers will make your code's tests live longer. So my advice is to stay away from things like `.should ==` and just write `.must_equal` instead. However, if matchers are really your thing, I recommend the [minitest-matchers](https://github.com/wojtekmach/minitest-matchers) gem. You can also check out the [valid_attribute](https://github.com/bcardarella/valid_attribute) gem built on top of minitest-matchers.
 
 ```ruby
 describe Post do

--- a/lib/minitest-spec-rails/init/active_support.rb
+++ b/lib/minitest-spec-rails/init/active_support.rb
@@ -4,7 +4,7 @@ module MiniTestSpecRails
       extend ActiveSupport::Concern
 
       included do
-        extend MiniTest::Spec::DSL
+        extend Minitest::Spec::DSL
         include MiniTestSpecRails::DSL
         include ActiveSupport::Testing::ConstantLookup
         extend Descriptions

--- a/minitest-spec-rails.gemspec
+++ b/minitest-spec-rails.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |gem|
   gem.authors     = ['Ken Collins']
   gem.email       = ['ken@metaskills.net']
   gem.homepage    = 'http://github.com/metaskills/minitest-spec-rails'
-  gem.summary     = 'Make Rails Use MiniTest::Spec!'
+  gem.summary     = 'Make Rails Use Minitest::Spec!'
   gem.description = 'The minitest-spec-rails gem makes it easy to use the \
-                     MiniTest::Spec DSL within your existing Rails test suite.'
+                     Minitest::Spec DSL within your existing Rails test suite.'
   gem.license     = 'MIT'
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/test/cases/action_cable_test.rb
+++ b/test/cases/action_cable_test.rb
@@ -4,26 +4,26 @@ class ModelsChannel < ApplicationCable::Channel;  end
 
 class ActionCableChannelTest < MiniTestSpecRails::TestCase
   it 'matches spec type for class constants' do
-    assert_channel_test MiniTest::Spec.spec_type(ApplicationCable::Channel)
-    assert_channel_test MiniTest::Spec.spec_type(ModelsChannel)
+    assert_channel_test Minitest::Spec.spec_type(ApplicationCable::Channel)
+    assert_channel_test Minitest::Spec.spec_type(ModelsChannel)
   end
 
   it 'matches spec type for strings' do
-    assert_channel_test MiniTest::Spec.spec_type('WidgetChannel')
-    assert_channel_test MiniTest::Spec.spec_type('WidgetChannelTest')
-    assert_channel_test MiniTest::Spec.spec_type('Widget Channel Test')
+    assert_channel_test Minitest::Spec.spec_type('WidgetChannel')
+    assert_channel_test Minitest::Spec.spec_type('WidgetChannelTest')
+    assert_channel_test Minitest::Spec.spec_type('Widget Channel Test')
     # And is case sensitive
-    refute_channel_test MiniTest::Spec.spec_type('widgetcontroller')
-    refute_channel_test MiniTest::Spec.spec_type('widgetcontrollertest')
-    refute_channel_test MiniTest::Spec.spec_type('widget controller test')
+    refute_channel_test Minitest::Spec.spec_type('widgetcontroller')
+    refute_channel_test Minitest::Spec.spec_type('widgetcontrollertest')
+    refute_channel_test Minitest::Spec.spec_type('widget controller test')
   end
 
   it 'wont match spec type for non space characters' do
-    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\tTest")
-    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\rTest")
-    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\nTest")
-    refute_channel_test MiniTest::Spec.spec_type("Widget Channel\fTest")
-    refute_channel_test MiniTest::Spec.spec_type('Widget ChannelXTest')
+    refute_channel_test Minitest::Spec.spec_type("Widget Channel\tTest")
+    refute_channel_test Minitest::Spec.spec_type("Widget Channel\rTest")
+    refute_channel_test Minitest::Spec.spec_type("Widget Channel\nTest")
+    refute_channel_test Minitest::Spec.spec_type("Widget Channel\fTest")
+    refute_channel_test Minitest::Spec.spec_type('Widget ChannelXTest')
   end
 
   private

--- a/test/cases/action_controller_test.rb
+++ b/test/cases/action_controller_test.rb
@@ -4,26 +4,26 @@ class ModelsController < ApplicationController;  end
 
 class ActionControllerTest < MiniTestSpecRails::TestCase
   it 'matches spec type for class constants' do
-    assert_controller MiniTest::Spec.spec_type(ApplicationController)
-    assert_controller MiniTest::Spec.spec_type(ModelsController)
+    assert_controller Minitest::Spec.spec_type(ApplicationController)
+    assert_controller Minitest::Spec.spec_type(ModelsController)
   end
 
   it 'matches spec type for strings' do
-    assert_controller MiniTest::Spec.spec_type('WidgetController')
-    assert_controller MiniTest::Spec.spec_type('WidgetControllerTest')
-    assert_controller MiniTest::Spec.spec_type('Widget Controller Test')
+    assert_controller Minitest::Spec.spec_type('WidgetController')
+    assert_controller Minitest::Spec.spec_type('WidgetControllerTest')
+    assert_controller Minitest::Spec.spec_type('Widget Controller Test')
     # And is case sensitive
-    refute_controller MiniTest::Spec.spec_type('widgetcontroller')
-    refute_controller MiniTest::Spec.spec_type('widgetcontrollertest')
-    refute_controller MiniTest::Spec.spec_type('widget controller test')
+    refute_controller Minitest::Spec.spec_type('widgetcontroller')
+    refute_controller Minitest::Spec.spec_type('widgetcontrollertest')
+    refute_controller Minitest::Spec.spec_type('widget controller test')
   end
 
   it 'wont match spec type for non space characters' do
-    refute_controller MiniTest::Spec.spec_type("Widget Controller\tTest")
-    refute_controller MiniTest::Spec.spec_type("Widget Controller\rTest")
-    refute_controller MiniTest::Spec.spec_type("Widget Controller\nTest")
-    refute_controller MiniTest::Spec.spec_type("Widget Controller\fTest")
-    refute_controller MiniTest::Spec.spec_type('Widget ControllerXTest')
+    refute_controller Minitest::Spec.spec_type("Widget Controller\tTest")
+    refute_controller Minitest::Spec.spec_type("Widget Controller\rTest")
+    refute_controller Minitest::Spec.spec_type("Widget Controller\nTest")
+    refute_controller Minitest::Spec.spec_type("Widget Controller\fTest")
+    refute_controller Minitest::Spec.spec_type('Widget ControllerXTest')
   end
 
   private

--- a/test/cases/action_dispatch_test.rb
+++ b/test/cases/action_dispatch_test.rb
@@ -4,35 +4,35 @@ class ModelsController < ApplicationController;  end
 
 class ActionControllerTest < MiniTestSpecRails::TestCase
   it 'resolves spec type for matching acceptance strings' do
-    assert_dispatch MiniTest::Spec.spec_type('WidgetAcceptanceTest')
-    assert_dispatch MiniTest::Spec.spec_type('Widget Acceptance Test')
+    assert_dispatch Minitest::Spec.spec_type('WidgetAcceptanceTest')
+    assert_dispatch Minitest::Spec.spec_type('Widget Acceptance Test')
     # And is case sensitive
-    refute_dispatch MiniTest::Spec.spec_type('widgetacceptancetest')
-    refute_dispatch MiniTest::Spec.spec_type('widget acceptance test')
+    refute_dispatch Minitest::Spec.spec_type('widgetacceptancetest')
+    refute_dispatch Minitest::Spec.spec_type('widget acceptance test')
   end
 
   it 'wont match spec type for space characters in acceptance strings' do
-    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\tTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\rTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\nTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget Acceptance\fTest")
-    refute_dispatch MiniTest::Spec.spec_type('Widget AcceptanceXTest')
+    refute_dispatch Minitest::Spec.spec_type("Widget Acceptance\tTest")
+    refute_dispatch Minitest::Spec.spec_type("Widget Acceptance\rTest")
+    refute_dispatch Minitest::Spec.spec_type("Widget Acceptance\nTest")
+    refute_dispatch Minitest::Spec.spec_type("Widget Acceptance\fTest")
+    refute_dispatch Minitest::Spec.spec_type('Widget AcceptanceXTest')
   end
 
   it 'resolves spec type for matching integration strings' do
-    assert_dispatch MiniTest::Spec.spec_type('WidgetIntegrationTest')
-    assert_dispatch MiniTest::Spec.spec_type('Widget Integration Test')
+    assert_dispatch Minitest::Spec.spec_type('WidgetIntegrationTest')
+    assert_dispatch Minitest::Spec.spec_type('Widget Integration Test')
     # And is case sensitive
-    refute_dispatch MiniTest::Spec.spec_type('widgetintegrationtest')
-    refute_dispatch MiniTest::Spec.spec_type('widget integration test')
+    refute_dispatch Minitest::Spec.spec_type('widgetintegrationtest')
+    refute_dispatch Minitest::Spec.spec_type('widget integration test')
   end
 
   it 'wont match spec type for space characters in integration strings' do
-    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\tTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\rTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\nTest")
-    refute_dispatch MiniTest::Spec.spec_type("Widget Integration\fTest")
-    refute_dispatch MiniTest::Spec.spec_type('Widget IntegrationXTest')
+    refute_dispatch Minitest::Spec.spec_type("Widget Integration\tTest")
+    refute_dispatch Minitest::Spec.spec_type("Widget Integration\rTest")
+    refute_dispatch Minitest::Spec.spec_type("Widget Integration\nTest")
+    refute_dispatch Minitest::Spec.spec_type("Widget Integration\fTest")
+    refute_dispatch Minitest::Spec.spec_type('Widget IntegrationXTest')
   end
 
   private

--- a/test/cases/action_mailer_test.rb
+++ b/test/cases/action_mailer_test.rb
@@ -5,26 +5,26 @@ class Notifications < ActionMailer::Base; end
 
 class ActionMailerTest < MiniTestSpecRails::TestCase
   it 'matches spec type for class constants' do
-    assert_mailer MiniTest::Spec.spec_type(NotificationMailer)
-    assert_mailer MiniTest::Spec.spec_type(Notifications)
+    assert_mailer Minitest::Spec.spec_type(NotificationMailer)
+    assert_mailer Minitest::Spec.spec_type(Notifications)
   end
 
   it 'matches spec type for strings' do
-    assert_mailer MiniTest::Spec.spec_type('WidgetMailer')
-    assert_mailer MiniTest::Spec.spec_type('WidgetMailerTest')
-    assert_mailer MiniTest::Spec.spec_type('Widget Mailer Test')
+    assert_mailer Minitest::Spec.spec_type('WidgetMailer')
+    assert_mailer Minitest::Spec.spec_type('WidgetMailerTest')
+    assert_mailer Minitest::Spec.spec_type('Widget Mailer Test')
     # And is case sensitive
-    refute_mailer MiniTest::Spec.spec_type('widgetmailer')
-    refute_mailer MiniTest::Spec.spec_type('widgetmailertest')
-    refute_mailer MiniTest::Spec.spec_type('widget mailer test')
+    refute_mailer Minitest::Spec.spec_type('widgetmailer')
+    refute_mailer Minitest::Spec.spec_type('widgetmailertest')
+    refute_mailer Minitest::Spec.spec_type('widget mailer test')
   end
 
   it 'wont match spec type for non space characters' do
-    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\tTest")
-    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\rTest")
-    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\nTest")
-    refute_mailer MiniTest::Spec.spec_type("Widget Mailer\fTest")
-    refute_mailer MiniTest::Spec.spec_type('Widget MailerXTest')
+    refute_mailer Minitest::Spec.spec_type("Widget Mailer\tTest")
+    refute_mailer Minitest::Spec.spec_type("Widget Mailer\rTest")
+    refute_mailer Minitest::Spec.spec_type("Widget Mailer\nTest")
+    refute_mailer Minitest::Spec.spec_type("Widget Mailer\fTest")
+    refute_mailer Minitest::Spec.spec_type('Widget MailerXTest')
   end
 
   private

--- a/test/cases/action_view_test.rb
+++ b/test/cases/action_view_test.rb
@@ -2,31 +2,31 @@ require 'test_helper'
 
 class ActionViewTest < MiniTestSpecRails::TestCase
   it 'resolves spec type for matching helper strings' do
-    assert_view MiniTest::Spec.spec_type('WidgetHelper')
-    assert_view MiniTest::Spec.spec_type('WidgetHelperTest')
-    assert_view MiniTest::Spec.spec_type('Widget Helper Test')
+    assert_view Minitest::Spec.spec_type('WidgetHelper')
+    assert_view Minitest::Spec.spec_type('WidgetHelperTest')
+    assert_view Minitest::Spec.spec_type('Widget Helper Test')
     # And is case sensitive
-    refute_view MiniTest::Spec.spec_type('widgethelper')
-    refute_view MiniTest::Spec.spec_type('widgethelpertest')
-    refute_view MiniTest::Spec.spec_type('widget helper test')
+    refute_view Minitest::Spec.spec_type('widgethelper')
+    refute_view Minitest::Spec.spec_type('widgethelpertest')
+    refute_view Minitest::Spec.spec_type('widget helper test')
   end
 
   it 'resolves spec type for matching view strings' do
-    assert_view MiniTest::Spec.spec_type('WidgetView')
-    assert_view MiniTest::Spec.spec_type('WidgetViewTest')
-    assert_view MiniTest::Spec.spec_type('Widget View Test')
+    assert_view Minitest::Spec.spec_type('WidgetView')
+    assert_view Minitest::Spec.spec_type('WidgetViewTest')
+    assert_view Minitest::Spec.spec_type('Widget View Test')
     # And is case sensitive
-    refute_view MiniTest::Spec.spec_type('widgetview')
-    refute_view MiniTest::Spec.spec_type('widgetviewtest')
-    refute_view MiniTest::Spec.spec_type('widget view test')
+    refute_view Minitest::Spec.spec_type('widgetview')
+    refute_view Minitest::Spec.spec_type('widgetviewtest')
+    refute_view Minitest::Spec.spec_type('widget view test')
   end
 
   it 'wont match spec type for non space characters' do
-    refute_view MiniTest::Spec.spec_type("Widget Helper\tTest")
-    refute_view MiniTest::Spec.spec_type("Widget Helper\rTest")
-    refute_view MiniTest::Spec.spec_type("Widget Helper\nTest")
-    refute_view MiniTest::Spec.spec_type("Widget Helper\fTest")
-    refute_view MiniTest::Spec.spec_type('Widget HelperXTest')
+    refute_view Minitest::Spec.spec_type("Widget Helper\tTest")
+    refute_view Minitest::Spec.spec_type("Widget Helper\rTest")
+    refute_view Minitest::Spec.spec_type("Widget Helper\nTest")
+    refute_view Minitest::Spec.spec_type("Widget Helper\fTest")
+    refute_view Minitest::Spec.spec_type('Widget HelperXTest')
   end
 
   private

--- a/test/cases/active_job_test.rb
+++ b/test/cases/active_job_test.rb
@@ -11,26 +11,26 @@ if defined?(ActiveJob)
 
   class ActiveJobTest < MiniTestSpecRails::TestCase
     it 'matches spec type for class constants' do
-      assert_job MiniTest::Spec.spec_type(MyJob)
-      assert_job MiniTest::Spec.spec_type(TrashableCleanupJob)
+      assert_job Minitest::Spec.spec_type(MyJob)
+      assert_job Minitest::Spec.spec_type(TrashableCleanupJob)
     end
 
     it 'matches spec type for strings' do
-      assert_job MiniTest::Spec.spec_type('WidgetJob')
-      assert_job MiniTest::Spec.spec_type('WidgetJobTest')
-      assert_job MiniTest::Spec.spec_type('Widget Job Test')
+      assert_job Minitest::Spec.spec_type('WidgetJob')
+      assert_job Minitest::Spec.spec_type('WidgetJobTest')
+      assert_job Minitest::Spec.spec_type('Widget Job Test')
       # And is case sensitive
-      refute_job MiniTest::Spec.spec_type('widgetmailer')
-      refute_job MiniTest::Spec.spec_type('widgetmailertest')
-      refute_job MiniTest::Spec.spec_type('widget mailer test')
+      refute_job Minitest::Spec.spec_type('widgetmailer')
+      refute_job Minitest::Spec.spec_type('widgetmailertest')
+      refute_job Minitest::Spec.spec_type('widget mailer test')
     end
 
     it 'wont match spec type for non space characters' do
-      refute_job MiniTest::Spec.spec_type("Widget Job\tTest")
-      refute_job MiniTest::Spec.spec_type("Widget Job\rTest")
-      refute_job MiniTest::Spec.spec_type("Widget Job\nTest")
-      refute_job MiniTest::Spec.spec_type("Widget Job\fTest")
-      refute_job MiniTest::Spec.spec_type('Widget JobXTest')
+      refute_job Minitest::Spec.spec_type("Widget Job\tTest")
+      refute_job Minitest::Spec.spec_type("Widget Job\rTest")
+      refute_job Minitest::Spec.spec_type("Widget Job\nTest")
+      refute_job Minitest::Spec.spec_type("Widget Job\fTest")
+      refute_job Minitest::Spec.spec_type('Widget JobXTest')
     end
 
     private

--- a/test/cases/active_support_test.rb
+++ b/test/cases/active_support_test.rb
@@ -4,12 +4,12 @@ class SomeRandomModel < ActiveRecord::Base; end
 
 class ActiveSupportTest < MiniTestSpecRails::TestCase
   it 'resolves spec type for active record constants' do
-    assert_support MiniTest::Spec.spec_type(SomeRandomModel)
-    assert_support MiniTest::Spec.spec_type(User)
+    assert_support Minitest::Spec.spec_type(SomeRandomModel)
+    assert_support Minitest::Spec.spec_type(User)
   end
 
   it 'wont resolve spec type for random strings' do
-    assert_spec MiniTest::Spec.spec_type('Unmatched String')
+    assert_spec Minitest::Spec.spec_type('Unmatched String')
   end
 
   private
@@ -19,7 +19,7 @@ class ActiveSupportTest < MiniTestSpecRails::TestCase
   end
 
   def assert_spec(actual)
-    assert_equal MiniTest::Spec, actual
+    assert_equal Minitest::Spec, actual
   end
 end
 

--- a/test/dummy_app/app/controllers/application_controller.rb
+++ b/test/dummy_app/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   def index
-    render html: '<h1>Rendered MiniTest::Spec</h1>'.html_safe, layout: false
+    render html: '<h1>Rendered Minitest::Spec</h1>'.html_safe, layout: false
   end
 end

--- a/test/dummy_app/app/mailers/user_mailer.rb
+++ b/test/dummy_app/app/mailers/user_mailer.rb
@@ -3,6 +3,6 @@ class UserMailer < ActionMailer::Base
 
   def welcome(user)
     @user = user
-    mail to: @user.email, subject: 'Welcome', body: "Welcome to MiniTest::Spec #{@user.email}!"
+    mail to: @user.email, subject: 'Welcome', body: "Welcome to Minitest::Spec #{@user.email}!"
   end
 end

--- a/test/dummy_tests/application_controller_test.rb
+++ b/test/dummy_tests/application_controller_test.rb
@@ -7,11 +7,11 @@ module ApplicationControllerTests
 
     it 'works' do
       get :index
-      expect(response.body).must_equal '<h1>Rendered MiniTest::Spec</h1>'
+      expect(response.body).must_equal '<h1>Rendered Minitest::Spec</h1>'
     end
 
     it 'allows custom assertions' do
-      assert_select 'h1', text: 'Rendered MiniTest::Spec'
+      assert_select 'h1', text: 'Rendered Minitest::Spec'
     end
 
     it 'can find the controller_class' do

--- a/test/dummy_tests/user_mailer_test.rb
+++ b/test/dummy_tests/user_mailer_test.rb
@@ -17,7 +17,7 @@ module UserMailerTests
       expect(deliveries).wont_be :empty?
       expect(user_email.to).must_equal    [user_ken.email]
       expect(user_email.from).must_equal  ['rails@minitest.spec']
-      expect(user_email.body.encoded).must_equal "Welcome to MiniTest::Spec #{user_ken.email}!"
+      expect(user_email.body.encoded).must_equal "Welcome to Minitest::Spec #{user_ken.email}!"
     end
 
     it 'allows custom assertions' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require 'dummy_app/init'
 require 'support/shared_test_case_behavior'
 
 module MiniTestSpecRails
-  class TestCase < MiniTest::Spec
+  class TestCase < Minitest::Spec
     include MiniTestSpecRails::SharedTestCaseBehavior
   end
 end


### PR DESCRIPTION
the rename happened in 5.0, which is the minimum version we support

but 5.19.0 started to only define the old alias when ENV["MT_COMPAT"] is defined, which usually is not the case