### PR TITLE
Use Minitest over MiniTest since it has been deprecated

### DIFF
--- a/lib/minitest-spec-rails/init/active_support.rb
+++ b/lib/minitest-spec-rails/init/active_support.rb
@@ -4,7 +4,7 @@ module MiniTestSpecRails
       extend ActiveSupport::Concern
 
       included do
-        extend MiniTest::Spec::DSL
+        extend Minitest::Spec::DSL
         include MiniTestSpecRails::DSL
         include ActiveSupport::Testing::ConstantLookup
         extend Descriptions


### PR DESCRIPTION
Fixes #120 

It now requires an extra ENV variable to work with MiniTest, instead I think it's better to use the new constant we're supposed to use. 

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6