### PR TITLE
Wrap action_view initializer loading in config.to_prepare block

### DIFF
--- a/lib/minitest-spec-rails/railtie.rb
+++ b/lib/minitest-spec-rails/railtie.rb
@@ -23,8 +23,10 @@ module MiniTestSpecRails
     end
 
     initializer 'minitest-spec-rails.action_view', after: 'action_view.setup_action_pack', group: :all do |_app|
-      ActiveSupport.on_load(:action_view) do
-        require 'minitest-spec-rails/init/action_view'
+      Rails.application.config.to_prepare do
+        ActiveSupport.on_load(:action_view) do
+          require 'minitest-spec-rails/init/action_view'
+        end
       end
     end
 


### PR DESCRIPTION
After updating an application to Rails 7 there was an error related to class loading.  This happened during  during initialization when running tests.  

Wrapping the call to the action_view initializer in a config.to_prepare block fixes the issue.

All appraisal tests pass with this change.  In addition, I have verified that this fix also works with Rails 6.1 tested against the application before the Rails 7 upgrade.