### PR TITLE
Avoid using send since the method name is constant

### DIFF
--- a/lib/minitest-spec-rails/init/action_controller.rb
+++ b/lib/minitest-spec-rails/init/action_controller.rb
@@ -19,4 +19,4 @@ module MiniTestSpecRails
   end
 end
 
-ActionController::TestCase.send :include, MiniTestSpecRails::Init::ActionControllerBehavior
+ActionController::TestCase.include MiniTestSpecRails::Init::ActionControllerBehavior

--- a/lib/minitest-spec-rails/init/action_dispatch.rb
+++ b/lib/minitest-spec-rails/init/action_dispatch.rb
@@ -11,4 +11,4 @@ module MiniTestSpecRails
   end
 end
 
-ActionDispatch::IntegrationTest.send :include, MiniTestSpecRails::Init::ActionDispatchBehavior
+ActionDispatch::IntegrationTest.include MiniTestSpecRails::Init::ActionDispatchBehavior

--- a/lib/minitest-spec-rails/init/action_mailer.rb
+++ b/lib/minitest-spec-rails/init/action_mailer.rb
@@ -19,4 +19,4 @@ module MiniTestSpecRails
   end
 end
 
-ActionMailer::TestCase.send :include, MiniTestSpecRails::Init::ActionMailerBehavior
+ActionMailer::TestCase.include MiniTestSpecRails::Init::ActionMailerBehavior

--- a/lib/minitest-spec-rails/init/action_view.rb
+++ b/lib/minitest-spec-rails/init/action_view.rb
@@ -19,4 +19,4 @@ module MiniTestSpecRails
   end
 end
 
-ActionView::TestCase.send :include, MiniTestSpecRails::Init::ActionViewBehavior
+ActionView::TestCase.include MiniTestSpecRails::Init::ActionViewBehavior

--- a/lib/minitest-spec-rails/init/active_job.rb
+++ b/lib/minitest-spec-rails/init/active_job.rb
@@ -21,4 +21,4 @@ module MiniTestSpecRails
   end
 end
 
-ActiveJob::TestCase.send :include, MiniTestSpecRails::Init::ActiveJobBehavior
+ActiveJob::TestCase.include MiniTestSpecRails::Init::ActiveJobBehavior

--- a/lib/minitest-spec-rails/init/active_support.rb
+++ b/lib/minitest-spec-rails/init/active_support.rb
@@ -29,4 +29,4 @@ module MiniTestSpecRails
   end
 end
 
-ActiveSupport::TestCase.send :include, MiniTestSpecRails::Init::ActiveSupportBehavior
+ActiveSupport::TestCase.include MiniTestSpecRails::Init::ActiveSupportBehavior

--- a/lib/minitest-spec-rails/init/mini_shoulda.rb
+++ b/lib/minitest-spec-rails/init/mini_shoulda.rb
@@ -20,4 +20,4 @@ module MiniTestSpecRails
   end
 end
 
-ActiveSupport::TestCase.send :include, MiniTestSpecRails::Init::MiniShouldaBehavior
+ActiveSupport::TestCase.include MiniTestSpecRails::Init::MiniShouldaBehavior


### PR DESCRIPTION
This is really superficial; it won't really change a thing; it's just something that I thought looked more complex than it should. 