### PR TITLE
Fix require `action_cable/channel/test_case` errors with Rails 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix require `action_cable/channel/test_case` errors with Rails 5.x. Fixes #124
+
 ## 7.2.0
 
 - Wrap action_view init in config.to_prepare block. Fixes #122. Thanks @Hal-Sumi

--- a/lib/minitest-spec-rails/init/action_cable.rb
+++ b/lib/minitest-spec-rails/init/action_cable.rb
@@ -2,27 +2,29 @@ unless defined?(ActionCable::Channel)
   require 'action_cable/channel'
 end
 
-require 'action_cable/channel/test_case'
+if Rails::VERSION::MAJOR >= 6
+  require 'action_cable/channel/test_case'
 
-module MiniTestSpecRails
-  module Init
-    module ActionCableBehavior
-      extend ActiveSupport::Concern
+  module MiniTestSpecRails
+    module Init
+      module ActionCableBehavior
+        extend ActiveSupport::Concern
 
-      included do
-        class_attribute :_helper_class
-        register_spec_type(/(Channel)( ?Test)?\z/, self)
-        register_spec_type(self) { |desc| desc.is_a?(Class) && desc < self }
-        extend Descriptions
-      end
+        included do
+          class_attribute :_helper_class
+          register_spec_type(/(Channel)( ?Test)?\z/, self)
+          register_spec_type(self) { |desc| desc.is_a?(Class) && desc < self }
+          extend Descriptions
+        end
 
-      module Descriptions
-        def described_class
-          determine_default_helper_class(name)
+        module Descriptions
+          def described_class
+            determine_default_helper_class(name)
+          end
         end
       end
     end
   end
-end
 
-ActionCable::Channel::TestCase.include MiniTestSpecRails::Init::ActionCableBehavior
+  ActionCable::Channel::TestCase.include MiniTestSpecRails::Init::ActionCableBehavior
+end


### PR DESCRIPTION
Fixes #124 

Did not add Rails 5.x to the CI as that would likely require some changing in the way Ruby/Rails versions are handled in the CI matrix and likely other changes to the test/dummy_app

Manually confirmed this fix is working as expected in the CI for my gem (at least for Rails 5.2.x)