### PR TITLE
Fix data leakage issue - always return true from register_spec_type block

### DIFF
--- a/lib/minitest-spec-rails/init/active_support.rb
+++ b/lib/minitest-spec-rails/init/active_support.rb
@@ -8,7 +8,7 @@ module MiniTestSpecRails
         include MiniTestSpecRails::DSL
         include ActiveSupport::Testing::ConstantLookup
         extend Descriptions
-        register_spec_type(self) { |desc| desc.is_a?(Class) }
+        register_spec_type(self) { |_desc| true }
       end
 
       module Descriptions


### PR DESCRIPTION
Attempts to resolve: https://github.com/metaskills/minitest-spec-rails/issues/115#issuecomment-2479332799

Data will be leaked if anything other than a `class` is passed as the argument to `description` because of this condition here:

https://github.com/metaskills/minitest-spec-rails/blob/1d09d588c1ca02ce0563ffc7ef48a65bd05b52af/lib/minitest-spec-rails/init/active_support.rb#L11

I bumped into this because we were passing a module as the description and doing so causes data leakage (no transaction rollback).

When the block returns false, the call to `spec_type` [here](https://github.com/minitest/minitest/blob/master/lib/minitest/spec.rb#L88) will return `Minitest::Spec < Minitest::Test` wich is the [default](https://github.com/minitest/minitest/blob/master/lib/minitest/spec.rb#L128). However, if the block returns true then `spec_type` returns `ActiveSupport::TestCase < Minitest::Test` (and `ActiveSupport::TestCase` handles the transaction properly).

Changing the block to `register_spec_type(self) { true }` resolve it, but I'm not certain that it is correct.

@metaskills any thoughts here? Do you recall why the block cares if the argument to describe is a `Class` (vs module, string, etc)?